### PR TITLE
fix for #4

### DIFF
--- a/src/pages/register.jsx
+++ b/src/pages/register.jsx
@@ -96,15 +96,22 @@ export default function Register() {
           <RadioSelect 
             id={"use_id_as_identifier"} 
             name={"use_id_as_identifier"} 
-            label={"Using ID or Email as identifier?"} 
+            label={"Using ID or Email as an identifier?"} 
             className="col-span-full"
             defaultChecked={selectedIdentifierMethod}
             array={identifierMethods}
-            onChange={(e)=>setSelectedIdentifierMethod(e.target.id)}
+            onChange={(e)=>{
+              setSelectedIdentifierMethod(e.target.id);
+              // remove value from id input;
+              if (e.target.id != identifierMethods[0].id) {
+                const idInput = document.querySelector("input#id");
+                idInput.value = "";
+              }
+            }}
           />
           <TextField
-            className="col-span-full"
-            label="Select a username"
+            className={`col-span-full${selectedIdentifierMethod != identifierMethods[0].id ? " hidden" : ""}`}
+            label="ID"
             id="id"
             name="id"
             type="text"


### PR DESCRIPTION
Fix for issue #4

***
The form's JS does a little extra work to ensure the identify call uses the `email` value as the identifier when the user selects that option on the register form.

This is so things like in-app messaging will work as expected (identifying with `email` -> target audience should be `{{customer.email}}` and vice-versa)

There is a little bug introduced because of this logic. If you filled out the `id` input, then changed the identifier preference to use `email`, the `id` value is overwritten with the `email` value.

This fix resets the value back to `""` and hides the `id` input label and field. 